### PR TITLE
Adding ternary statement to the UriEncode to allow apostrophes in a url

### DIFF
--- a/Razor.Blade/Markup/Tag/Tag_UriEncode.cs
+++ b/Razor.Blade/Markup/Tag/Tag_UriEncode.cs
@@ -22,7 +22,7 @@ namespace ToSic.Razor.Markup
             // simple use case - no % character in url
             // or the % wasn't just used for encoding
             // so just perform standard encoding
-            return Uri.EscapeUriString(url);
+            return (url.Contains("'") ? Uri.EscapeUriString(url).Replace("'", "%27") : Uri.EscapeUriString(url));
         }
 
         internal static string UriEncodeSrcSet(string srcSet)


### PR DESCRIPTION
I have added a quick ternary statement into the Tag_UriEncode.cs file to allow for the apostrophe's to be encoded...

Weirdly, the replace needs to be done after the encode otherwise it encodes the "%27"

Regards

Kieran